### PR TITLE
t/3: The data controller should be initialized in DecoupledEditor.create

### DIFF
--- a/src/decouplededitor.js
+++ b/src/decouplededitor.js
@@ -157,7 +157,7 @@ export default class DecoupledEditor extends Editor {
 						editor.fire( 'uiReady' );
 					} )
 					.then( () => editor.editing.view.attachDomRoot( editor.ui.view.editableElement ) )
-					.then( () => editor.data.set( data ) )
+					.then( () => editor.data.init( data ) )
 					.then( () => {
 						editor.fire( 'dataReady' );
 						editor.fire( 'ready' );

--- a/tests/decouplededitor.js
+++ b/tests/decouplededitor.js
@@ -92,6 +92,33 @@ describe( 'DecoupledEditor', () => {
 				} );
 		} );
 
+		// https://github.com/ckeditor/ckeditor5-editor-decoupled/issues/3
+		it( 'initializes the data controller', () => {
+			let dataInitSpy;
+
+			class DataInitAssertPlugin extends Plugin {
+				constructor( editor ) {
+					super();
+
+					this.editor = editor;
+				}
+
+				init() {
+					dataInitSpy = sinon.spy( this.editor.data, 'init' );
+				}
+			}
+
+			return DecoupledEditor
+				.create( editorData, {
+					plugins: [ Paragraph, Bold, DataInitAssertPlugin ]
+				} )
+				.then( newEditor => {
+					sinon.assert.calledOnce( dataInitSpy );
+
+					return newEditor.destroy();
+				} );
+		} );
+
 		describe( 'ui', () => {
 			it( 'attaches editable UI as view\'s DOM root', () => {
 				expect( editor.editing.view.getDomRoot() ).to.equal( editor.ui.view.editable.element );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The data controller should be initialized in `DecoupledEditor.create()`. Closes #3.
