### PR TITLE
t/6: The DecoupledEditorUIView should register #toolbar and #editable views as children. Closes #6.

### DIFF
--- a/src/decouplededitoruiview.js
+++ b/src/decouplededitoruiview.js
@@ -55,16 +55,8 @@ export default class DecoupledEditorUIView extends EditorUIView {
 				class: 'ck-reset_all'
 			}
 		} );
-	}
 
-	/**
-	 * @inheritDoc
-	 */
-	render() {
-		super.render();
-
-		this.toolbar.render();
-		this.editable.render();
+		this.registerChildren( [ this.toolbar, this.editable ] );
 	}
 
 	/**
@@ -84,9 +76,6 @@ export default class DecoupledEditorUIView extends EditorUIView {
 		if ( removeEditable ) {
 			this.editable.element.remove();
 		}
-
-		this.toolbar.destroy();
-		this.editable.destroy();
 	}
 
 	/**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The `DecoupledEditorUIView` should register `#toolbar` and `#editable` views as children. Closes #6.
