### PR TITLE
Replace `ckeditor5-uitls/src/lib/lodash` imports with `lodash-es`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@ckeditor/ckeditor5-engine": "^10.2.0",
     "@ckeditor/ckeditor5-theme-lark": "^11.0.0",
     "@ckeditor/ckeditor5-ui": "^11.0.0",
-    "@ckeditor/ckeditor5-utils": "^10.2.0"
+    "@ckeditor/ckeditor5-utils": "^10.2.0",
+    "lodash-es": "^4.17.10"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "^10.0.2",

--- a/src/decouplededitor.js
+++ b/src/decouplededitor.js
@@ -15,7 +15,7 @@ import DecoupledEditorUIView from './decouplededitoruiview';
 import getDataFromElement from '@ckeditor/ckeditor5-utils/src/dom/getdatafromelement';
 import setDataInElement from '@ckeditor/ckeditor5-utils/src/dom/setdatainelement';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
-import isElement from '@ckeditor/ckeditor5-utils/src/lib/lodash/isElement';
+import { isElement } from 'lodash-es';
 
 /**
  * The {@glink builds/guides/overview#decoupled-editor decoupled editor} implementation.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Replaced `ckeditor5-uitls/src/lib/lodash` imports with `lodash-es`.

---

### Additional information

Part of the https://github.com/ckeditor/ckeditor5-utils/pull/252.