### PR TITLE
Adjustments to new `data#ready` event

### DIFF
--- a/src/decouplededitor.js
+++ b/src/decouplededitor.js
@@ -197,10 +197,7 @@ export default class DecoupledEditor extends Editor {
 
 						return editor.data.init( initialData );
 					} )
-					.then( () => {
-						editor.fire( 'dataReady' );
-						editor.fire( 'ready' );
-					} )
+					.then( () => editor.fire( 'ready' ) )
 					.then( () => editor )
 			);
 		} );

--- a/tests/decouplededitor.js
+++ b/tests/decouplededitor.js
@@ -187,12 +187,12 @@ describe( 'DecoupledEditor', () => {
 					const fired = [];
 
 					function spy( evt ) {
-						fired.push( evt.name );
+						fired.push( `${ evt.name }-${ evt.source.constructor.name.toLowerCase() }` );
 					}
 
 					class EventWatcher extends Plugin {
 						init() {
-							this.editor.on( 'pluginsReady', spy );
+							this.editor.plugins.on( 'ready', spy );
 							this.editor.ui.on( 'ready', spy );
 							this.editor.on( 'dataReady', spy );
 							this.editor.on( 'ready', spy );
@@ -204,7 +204,12 @@ describe( 'DecoupledEditor', () => {
 							plugins: [ EventWatcher ]
 						} )
 						.then( newEditor => {
-							expect( fired ).to.deep.equal( [ 'pluginsReady', 'ready', 'dataReady', 'ready' ] );
+							expect( fired ).to.deep.equal( [
+								'ready-plugincollection',
+								'ready-decouplededitorui',
+								'dataReady-decouplededitor',
+								'ready-decouplededitor'
+							] );
 
 							return newEditor.destroy();
 						} );

--- a/tests/decouplededitorui.js
+++ b/tests/decouplededitorui.js
@@ -209,7 +209,6 @@ class VirtualDecoupledTestEditor extends VirtualTestEditor {
 				editor.initPlugins()
 					.then( () => {
 						editor.ui.init();
-						editor.fire( 'dataReady' );
 						editor.fire( 'ready' );
 					} )
 					.then( () => editor )


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Adjustments to new `data#ready` event.

BREAKING CHANGE: The `editor#dataReady` event was removed. The `editor.data#ready` event has been introduced and should be used instead.

---

### Additional information

See https://github.com/ckeditor/ckeditor5/issues/1477.
