### PR TITLE
t/ckeditor5/1517: The editor placeholder configuration using the `placeholder` attribute should be restricted to `<textarea>` only

### DIFF
--- a/src/decouplededitorui.js
+++ b/src/decouplededitorui.js
@@ -135,7 +135,7 @@ export default class DecoupledEditorUI extends EditorUI {
 		const editingRoot = editingView.document.getRoot();
 
 		const placeholderText = editor.config.get( 'placeholder' ) ||
-			editor.sourceElement && editor.sourceElement.getAttribute( 'placeholder' );
+			editor.sourceElement && editor.sourceElement.dataset.placeholder;
 
 		if ( placeholderText ) {
 			enablePlaceholder( {

--- a/src/decouplededitorui.js
+++ b/src/decouplededitorui.js
@@ -133,9 +133,10 @@ export default class DecoupledEditorUI extends EditorUI {
 		const editor = this.editor;
 		const editingView = editor.editing.view;
 		const editingRoot = editingView.document.getRoot();
+		const sourceElement = editor.sourceElement;
 
 		const placeholderText = editor.config.get( 'placeholder' ) ||
-			editor.sourceElement && editor.sourceElement.dataset.placeholder;
+			sourceElement && sourceElement.tagName.toLowerCase() === 'textarea' && sourceElement.getAttribute( 'placeholder' );
 
 		if ( placeholderText ) {
 			enablePlaceholder( {

--- a/tests/decouplededitorui.js
+++ b/tests/decouplededitorui.js
@@ -98,10 +98,10 @@ describe( 'DecoupledEditorUI', () => {
 					} );
 			} );
 
-			it( 'sets placeholder from "placeholder" attribute of a passed element', () => {
+			it( 'sets placeholder from the "data-placeholder" attribute of a passed element', () => {
 				const element = document.createElement( 'div' );
 
-				element.setAttribute( 'placeholder', 'placeholder-text' );
+				element.dataset.placeholder = 'placeholder-text';
 
 				return VirtualDecoupledTestEditor
 					.create( element, {
@@ -116,10 +116,10 @@ describe( 'DecoupledEditorUI', () => {
 					} );
 			} );
 
-			it( 'uses editor.config.placeholder rather than "placeholder" attribute of a passed element', () => {
+			it( 'uses editor.config.placeholder rather than the "data-placeholder" attribute of a passed element', () => {
 				const element = document.createElement( 'div' );
 
-				element.setAttribute( 'placeholder', 'placeholder-text' );
+				element.dataset.placeholder = 'placeholder-text';
 
 				return VirtualDecoupledTestEditor
 					.create( element, {

--- a/tests/decouplededitorui.js
+++ b/tests/decouplededitorui.js
@@ -98,10 +98,10 @@ describe( 'DecoupledEditorUI', () => {
 					} );
 			} );
 
-			it( 'sets placeholder from the "data-placeholder" attribute of a passed element', () => {
-				const element = document.createElement( 'div' );
+			it( 'sets placeholder from the "placeholder" attribute of a passed <textarea>', () => {
+				const element = document.createElement( 'textarea' );
 
-				element.dataset.placeholder = 'placeholder-text';
+				element.setAttribute( 'placeholder', 'placeholder-text' );
 
 				return VirtualDecoupledTestEditor
 					.create( element, {
@@ -116,10 +116,10 @@ describe( 'DecoupledEditorUI', () => {
 					} );
 			} );
 
-			it( 'uses editor.config.placeholder rather than the "data-placeholder" attribute of a passed element', () => {
-				const element = document.createElement( 'div' );
+			it( 'uses editor.config.placeholder rather than the "placeholder" attribute of a passed <textarea>', () => {
+				const element = document.createElement( 'textarea' );
 
-				element.dataset.placeholder = 'placeholder-text';
+				element.setAttribute( 'placeholder', 'placeholder-text' );
 
 				return VirtualDecoupledTestEditor
 					.create( element, {

--- a/tests/manual/placeholder.html
+++ b/tests/manual/placeholder.html
@@ -1,5 +1,5 @@
-<div id="editor-1" placeholder="Placeholder from the attribute">
+<div id="editor-1" data-placeholder="Placeholder from the attribute">
 	<p>Remove this text to see the placeholder.</p>
 </div>
 <br />
-<div id="editor-2" placeholder="Placeholder from the attribute"></div>
+<div id="editor-2" data-placeholder="Placeholder from the attribute"></div>

--- a/tests/manual/placeholder.html
+++ b/tests/manual/placeholder.html
@@ -1,5 +1,5 @@
-<div id="editor-1" data-placeholder="Placeholder from the attribute">
+<textarea id="editor-1" placeholder="Placeholder from the attribute">
 	<p>Remove this text to see the placeholder.</p>
-</div>
+</textarea>
 <br />
 <div id="editor-2" data-placeholder="Placeholder from the attribute"></div>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The editor placeholder configuration using the `placeholder` attribute should be restricted to `<textarea>` only (see ckeditor/ckeditor5#1517).

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5/pull/1518.
