### PR TITLE
Introduced EditorConfig#initialData. Made config param optional

### DIFF
--- a/src/decouplededitor.js
+++ b/src/decouplededitor.js
@@ -113,91 +113,87 @@ export default class DecoupledEditor extends Editor {
 	}
 
 	/**
-	 * Creates a decoupled editor instance.
+	 * Creates a `DecoupledEditor` instance.
 	 *
-	 * Creating an instance when using a {@glink builds/index CKEditor 5 build}:
+	 * There are two general ways how the editor can be initialized. Remember that `DecoupledEditor` do not append the toolbar element
+	 * to your web page so you have to do it manually after the editor has been initialized.
+	 *
+	 * You can initialize the editor using an existing DOM element:
 	 *
 	 *		DecoupledEditor
 	 *			.create( document.querySelector( '#editor' ) )
 	 *			.then( editor => {
+	 *				console.log( 'Editor was initialized', editor );
+	 *
 	 *				// Append the toolbar to the <body> element.
 	 *				document.body.appendChild( editor.ui.view.toolbar.element );
-	 *
-	 *				console.log( 'Editor was initialized', editor );
 	 *			} )
 	 *			.catch( err => {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
-	 * Creating an instance when using CKEditor from source (make sure to specify the list of plugins to load and the toolbar):
+	 * The element's content will be used as the editor data. The editable element will replace the source element on your web page.
 	 *
-	 *		import DecoupledEditor from '@ckeditor/ckeditor5-editor-decoupled/src/decouplededitor';
-	 *		import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
-	 *		import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
-	 *		import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
-	 *		import ...
+	 * Alternatively, you can initialize the editor by passing the initial data directly as a `String`.
+	 * In this case, you will have to manually append to your web page both the toolbar element and the editable element.
 	 *
 	 *		DecoupledEditor
-	 *			.create( document.querySelector( '#editor' ), {
-	 *				plugins: [ Essentials, Bold, Italic, ... ],
-	 *				toolbar: [ 'bold', 'italic', ... ]
-	 *			} )
+	 *			.create( '<p>Hello world!</p>' )
 	 *			.then( editor => {
+	 *				console.log( 'Editor was initialized', editor );
+	 *
 	 *				// Append the toolbar to the <body> element.
 	 *				document.body.appendChild( editor.ui.view.toolbar.element );
 	 *
-	 *				console.log( 'Editor was initialized', editor );
+	 *				// Initial data was provided so the editor UI element needs to be added manually to the DOM.
+	 *				document.body.appendChild( editor.ui.element );
 	 *			} )
 	 *			.catch( err => {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
-	 * Creating an instance when using initial data instead of a DOM element.
-	 * The editor will then render an editable element that must be inserted into the DOM for the editor to work properly:
+	 * This let's you dynamically append the editor to your web page whenever it is convenient for you. You may use this method if your
+	 * web page content is generated on the client-side and the DOM structure is not ready at the moment when you initialize the editor.
 	 *
-	 *		DecoupledEditor
-	 *			.create( '<p>Editor data</p>' )
-	 *			.then( editor => {
-	 *				// Append the toolbar to the <body> element.
-	 *				document.body.appendChild( editor.ui.view.toolbar.element );
-	 *
-	 *				// Append the editable to the <body> element.
-	 *				document.body.appendChild( editor.ui.view.editable.element );
-	 *
-	 *				console.log( 'Editor was initialized', editor );
-	 *			} )
-	 *			.catch( err => {
-	 *				console.error( err.stack );
-	 *			} );
-	 *
-	 * Creating an instance on an existing DOM element using external initial content (specified in config):
+	 * You can also mix those two ways by providing a DOM element to be used and passing the initial data through the config:
 	 *
 	 *		DecoupledEditor
 	 *			.create( document.querySelector( '#editor' ), {
 	 *				initialData: '<h2>Initial data</h2><p>Foo bar.</p>'
 	 *			} )
 	 *			.then( editor => {
+	 *				console.log( 'Editor was initialized', editor );
+	 *
 	 *				// Append the toolbar to the <body> element.
 	 *				document.body.appendChild( editor.ui.view.toolbar.element );
-	 *
-	 *				console.log( 'Editor was initialized', editor );
 	 *			} )
 	 *			.catch( err => {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
+	 * This method can be used to initialize the editor on an existing element with specified content in case if your integration
+	 * makes it difficult to set the content of the source element.
+	 *
+	 * Note that an error will be thrown if you pass initial data both as the first parameter and also in the config.
+	 *
+	 * See also the {@link module:core/editor/editorconfig~EditorConfig editor configuration documentation} to learn more about
+	 * customizing plugins, toolbar and other.
+	 *
 	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
-	 * (on which the editor will be initialized) or initial data for the editor.
+	 * or the editor's initial data.
 	 *
-	 * If a source element is passed, then its contents will be automatically
-	 * {@link module:editor-decoupled/decouplededitor~DecoupledEditor#setData loaded} to the editor on startup and the element
-	 * itself will be used as the editor's editable element.
+	 * If a DOM element is passed, its content will be automatically
+	 * {@link module:editor-decoupled/decouplededitor~DecoupledEditor#setData loaded} to the editor upon initialization
+	 * and the {@link module:core/editor/editorui~EditorUI#getEditableElement editable element} will replace the passed element in the DOM
+	 * (the original element will be hidden and the editor will be injected next to it).
 	 *
-	 * If data is provided, then `editor.ui.view.editable.element` will be created automatically and needs to be added
-	 * to the DOM manually.
+	 * Moreover, the editor data will be set back to the original element once the editor is destroyed.
+	 *
+	 * If the initial data is passed, a detached editor will be created. In this case you need to insert it into the DOM manually.
+	 * It is available under {@link module:editor-classic/classiceditorui~DecoupledEditorUI#element `editor.ui.element`} property.
+	 *
 	 * @param {module:core/editor/editorconfig~EditorConfig} [config] The editor configuration.
-	 * @returns {Promise} A promise resolved once the editor is ready.
-	 * The promise returns the created {@link module:editor-decoupled/decouplededitor~DecoupledEditor} instance.
+	 * @returns {Promise} A promise resolved once the editor is ready. The promise resolves with the created editor instance.
 	 */
 	static create( sourceElementOrData, config = {} ) {
 		return new Promise( resolve => {

--- a/src/decouplededitor.js
+++ b/src/decouplededitor.js
@@ -134,7 +134,7 @@ export default class DecoupledEditor extends Editor {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
-	 * The element's content will be used as the editor data and it will become the editable element.
+	 * The element's content will be used as the editor data and the element will become the editable element.
 	 *
 	 * Alternatively, you can initialize the editor by passing the initial data directly as a `String`.
 	 * In this case, you will have to manually append to your web page both the toolbar element and the editable element.

--- a/src/decouplededitor.js
+++ b/src/decouplededitor.js
@@ -134,7 +134,7 @@ export default class DecoupledEditor extends Editor {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
-	 * The element's content will be used as the editor data. The editable element will replace the source element on your web page.
+	 * The element's content will be used as the editor data and it will become the editable element.
 	 *
 	 * Alternatively, you can initialize the editor by passing the initial data directly as a `String`.
 	 * In this case, you will have to manually append to your web page both the toolbar element and the editable element.

--- a/src/decouplededitor.js
+++ b/src/decouplededitor.js
@@ -152,7 +152,7 @@ export default class DecoupledEditor extends Editor {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
-	 * This let's you dynamically append the editor to your web page whenever it is convenient for you. You may use this method if your
+	 * This lets you dynamically append the editor to your web page whenever it is convenient for you. You may use this method if your
 	 * web page content is generated on the client-side and the DOM structure is not ready at the moment when you initialize the editor.
 	 *
 	 * You can also mix those two ways by providing a DOM element to be used and passing the initial data through the config:

--- a/src/decouplededitor.js
+++ b/src/decouplededitor.js
@@ -115,8 +115,10 @@ export default class DecoupledEditor extends Editor {
 	/**
 	 * Creates a `DecoupledEditor` instance.
 	 *
-	 * There are two general ways how the editor can be initialized. Remember that `DecoupledEditor` do not append the toolbar element
-	 * to your web page so you have to do it manually after the editor has been initialized.
+	 * Remember that `DecoupledEditor` do not append the toolbar element to your web page so you have to do it manually after the editor
+	 * has been initialized.
+	 *
+	 * There are two general ways how the editor can be initialized.
 	 *
 	 * You can initialize the editor using an existing DOM element:
 	 *
@@ -183,10 +185,7 @@ export default class DecoupledEditor extends Editor {
 	 * or the editor's initial data.
 	 *
 	 * If a DOM element is passed, its content will be automatically
-	 * {@link module:editor-decoupled/decouplededitor~DecoupledEditor#setData loaded} to the editor upon initialization
-	 * and the {@link module:core/editor/editorui~EditorUI#getEditableElement editable element} will replace the passed element in the DOM
-	 * (the original element will be hidden and the editor will be injected next to it).
-	 *
+	 * {@link module:editor-decoupled/decouplededitor~DecoupledEditor#initData loaded} to the editor upon initialization.
 	 * Moreover, the editor data will be set back to the original element once the editor is destroyed.
 	 *
 	 * If the initial data is passed, a detached editor will be created. In this case you need to insert it into the DOM manually.

--- a/src/decouplededitor.js
+++ b/src/decouplededitor.js
@@ -184,12 +184,11 @@ export default class DecoupledEditor extends Editor {
 	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
 	 * or the editor's initial data.
 	 *
-	 * If a DOM element is passed, its content will be automatically
-	 * {@link module:editor-decoupled/decouplededitor~DecoupledEditor#initData loaded} to the editor upon initialization.
+	 * If a DOM element is passed, its content will be automatically loaded to the editor upon initialization.
 	 * Moreover, the editor data will be set back to the original element once the editor is destroyed.
 	 *
 	 * If the initial data is passed, a detached editor will be created. In this case you need to insert it into the DOM manually.
-	 * It is available under {@link module:editor-classic/classiceditorui~DecoupledEditorUI#element `editor.ui.element`} property.
+	 * It is available under {@link module:editor-decoupled/decouplededitorui~DecoupledEditorUI#element `editor.ui.element`} property.
 	 *
 	 * @param {module:core/editor/editorconfig~EditorConfig} [config] The editor configuration.
 	 * @returns {Promise} A promise resolved once the editor is ready. The promise resolves with the created editor instance.

--- a/tests/decouplededitor.js
+++ b/tests/decouplededitor.js
@@ -114,6 +114,26 @@ describe( 'DecoupledEditor', () => {
 			test( () => editableElement );
 		} );
 
+		it( 'initializes with config.initialData', () => {
+			return DecoupledEditor.create( document.createElement( 'div' ), {
+				initialData: '<p>Hello world!</p>',
+				plugins: [ Paragraph ]
+			} ).then( editor => {
+				expect( editor.getData() ).to.equal( '<p>Hello world!</p>' );
+
+				editor.destroy();
+			} );
+		} );
+
+		it( 'throws if initial data is passed in Editor#create and config.initialData is also used', done => {
+			DecoupledEditor.create( '<p>Hello world!</p>', {
+				initialData: '<p>I am evil!</p>',
+				plugins: [ Paragraph ]
+			} ).catch( () => {
+				done();
+			} );
+		} );
+
 		function test( getElementOrData ) {
 			it( 'creates an instance which inherits from the DecoupledEditor', () => {
 				return DecoupledEditor
@@ -132,6 +152,19 @@ describe( 'DecoupledEditor', () => {
 					.create( getElementOrData(), {
 						plugins: [ Paragraph, Bold ]
 					} )
+					.then( newEditor => {
+						expect( newEditor.getData() ).to.equal( '<p><strong>foo</strong> bar</p>' );
+
+						return newEditor.destroy();
+					} );
+			} );
+
+			it( 'should not require config object', () => {
+				// Just being safe with `builtinPlugins` static property.
+				class CustomDecoupledEditor extends DecoupledEditor {}
+				CustomDecoupledEditor.builtinPlugins = [ Paragraph, Bold ];
+
+				return CustomDecoupledEditor.create( getElementOrData() )
 					.then( newEditor => {
 						expect( newEditor.getData() ).to.equal( '<p><strong>foo</strong> bar</p>' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced `EditorConfig#initialData`.

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5/issues/1619.

Also, I've made `config` parameter in `Editor.create()` optional. There is no need for it and we also have an example in docs without using it.