### PR TITLE
Added documentation for editor-create-initial-data error

### DIFF
--- a/src/decouplededitor.js
+++ b/src/decouplededitor.js
@@ -204,9 +204,14 @@ export default class DecoupledEditor extends Editor {
 					} )
 					.then( () => {
 						if ( !isElement( sourceElementOrData ) && config.initialData ) {
+							/**
+							 * Configuration parameter `initialData` cannot be used together with initial data passed in `Editor#create()`.
+							 *
+							 * @error editor-create-initial-data
+							 */
 							throw new CKEditorError(
 								'editor-create-initial-data: ' +
-								'EditorConfig#initialData cannot be used together with initial data passed in Editor#create()'
+								'Configuration parameter initialData cannot be used together with initial data passed in Editor#create()'
 							);
 						}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Added documentation for editor-create-initial-data error. Closes https://github.com/ckeditor/ckeditor5/issues/1665.