### PR TITLE
DecoupledEditor.create() will throw an error, when textarea element is used

### DIFF
--- a/src/decouplededitor.js
+++ b/src/decouplededitor.js
@@ -213,31 +213,30 @@ export default class DecoupledEditor extends Editor {
 	 * @returns {Promise} A promise resolved once the editor is ready. The promise resolves with the created editor instance.
 	 */
 	static create( sourceElementOrData, config = {} ) {
-		return new Promise( resolve => {
-			const editor = new this( sourceElementOrData, config );
+		let editor;
+		return Editor.allowedElement( sourceElementOrData )
+			.then( () => {
+				editor = new this( sourceElementOrData, config );
+			} )
+			.then( () => editor.initPlugins() )
+			.then( () => {
+				editor.ui.init();
+			} )
+			.then( () => {
+				if ( !isElement( sourceElementOrData ) && config.initialData ) {
+					// Documented in core/editor/editorconfig.jdoc.
+					throw new CKEditorError(
+						'editor-create-initial-data: ' +
+						'The config.initialData option cannot be used together with initial data passed in Editor.create().'
+					);
+				}
 
-			resolve(
-				editor.initPlugins()
-					.then( () => {
-						editor.ui.init();
-					} )
-					.then( () => {
-						if ( !isElement( sourceElementOrData ) && config.initialData ) {
-							// Documented in core/editor/editorconfig.jdoc.
-							throw new CKEditorError(
-								'editor-create-initial-data: ' +
-								'The config.initialData option cannot be used together with initial data passed in Editor.create().'
-							);
-						}
+				const initialData = config.initialData || getInitialData( sourceElementOrData );
 
-						const initialData = config.initialData || getInitialData( sourceElementOrData );
-
-						return editor.data.init( initialData );
-					} )
-					.then( () => editor.fire( 'ready' ) )
-					.then( () => editor )
-			);
-		} );
+				return editor.data.init( initialData );
+			} )
+			.then( () => editor.fire( 'ready' ) )
+			.then( () => editor );
 	}
 }
 

--- a/src/decouplededitor.js
+++ b/src/decouplededitor.js
@@ -214,7 +214,12 @@ export default class DecoupledEditor extends Editor {
 	 */
 	static create( sourceElementOrData, config = {} ) {
 		return new Promise( resolve => {
-			Editor._assertAllowedSourceElement( sourceElementOrData );
+			const isHTMLElement = isElement( sourceElementOrData );
+
+			if ( isHTMLElement && sourceElementOrData.tagName === 'TEXTAREA' ) {
+				// Documented in core/editor/editor.js
+				throw new CKEditorError( 'editor-wrong-element: This type of editor cannot be initialized inside <textarea> element.' );
+			}
 
 			const editor = new this( sourceElementOrData, config );
 
@@ -224,7 +229,7 @@ export default class DecoupledEditor extends Editor {
 						editor.ui.init();
 					} )
 					.then( () => {
-						if ( !isElement( sourceElementOrData ) && config.initialData ) {
+						if ( !isHTMLElement && config.initialData ) {
 							// Documented in core/editor/editorconfig.jdoc.
 							throw new CKEditorError(
 								'editor-create-initial-data: ' +

--- a/src/decouplededitor.js
+++ b/src/decouplededitor.js
@@ -214,6 +214,8 @@ export default class DecoupledEditor extends Editor {
 	 */
 	static create( sourceElementOrData, config = {} ) {
 		return new Promise( resolve => {
+			Editor._assertAllowedSourceElement( sourceElementOrData );
+
 			const editor = new this( sourceElementOrData, config );
 
 			resolve(

--- a/src/decouplededitor.js
+++ b/src/decouplededitor.js
@@ -213,30 +213,31 @@ export default class DecoupledEditor extends Editor {
 	 * @returns {Promise} A promise resolved once the editor is ready. The promise resolves with the created editor instance.
 	 */
 	static create( sourceElementOrData, config = {} ) {
-		let editor;
-		return Editor.allowedElement( sourceElementOrData )
-			.then( () => {
-				editor = new this( sourceElementOrData, config );
-			} )
-			.then( () => editor.initPlugins() )
-			.then( () => {
-				editor.ui.init();
-			} )
-			.then( () => {
-				if ( !isElement( sourceElementOrData ) && config.initialData ) {
-					// Documented in core/editor/editorconfig.jdoc.
-					throw new CKEditorError(
-						'editor-create-initial-data: ' +
-						'The config.initialData option cannot be used together with initial data passed in Editor.create().'
-					);
-				}
+		return new Promise( resolve => {
+			const editor = new this( sourceElementOrData, config );
 
-				const initialData = config.initialData || getInitialData( sourceElementOrData );
+			resolve(
+				editor.initPlugins()
+					.then( () => {
+						editor.ui.init();
+					} )
+					.then( () => {
+						if ( !isElement( sourceElementOrData ) && config.initialData ) {
+							// Documented in core/editor/editorconfig.jdoc.
+							throw new CKEditorError(
+								'editor-create-initial-data: ' +
+								'The config.initialData option cannot be used together with initial data passed in Editor.create().'
+							);
+						}
 
-				return editor.data.init( initialData );
-			} )
-			.then( () => editor.fire( 'ready' ) )
-			.then( () => editor );
+						const initialData = config.initialData || getInitialData( sourceElementOrData );
+
+						return editor.data.init( initialData );
+					} )
+					.then( () => editor.fire( 'ready' ) )
+					.then( () => editor )
+			);
+		} );
 	}
 }
 

--- a/tests/decouplededitor.js
+++ b/tests/decouplededitor.js
@@ -134,6 +134,21 @@ describe( 'DecoupledEditor', () => {
 			} );
 		} );
 
+		it( 'throws error if it is initialized in textarea', done => {
+			DecoupledEditor.create( document.createElement( 'textarea' ) )
+				.then(
+					() => {
+						expect.fail( 'Decoupled editor should throw an error when is initialized in textarea.' );
+					},
+					err => {
+						expect( err ).to.be.an( 'error' ).with.property( 'message' ).and
+							.match( /^editor-wrong-element: This type of editor cannot be initialized inside <textarea> element\./ );
+					}
+				)
+				.then( done )
+				.catch( done );
+		} );
+
 		function test( getElementOrData ) {
 			it( 'creates an instance which inherits from the DecoupledEditor', () => {
 				return DecoupledEditor

--- a/tests/decouplededitor.js
+++ b/tests/decouplededitor.js
@@ -129,9 +129,19 @@ describe( 'DecoupledEditor', () => {
 			DecoupledEditor.create( '<p>Hello world!</p>', {
 				initialData: '<p>I am evil!</p>',
 				plugins: [ Paragraph ]
-			} ).catch( () => {
-				done();
-			} );
+			} )
+				.then(
+					() => {
+						expect.fail( 'Decoupled editor should throw an error when both initial data are passed' );
+					},
+					err => {
+						expect( err ).to.be.an( 'error' ).with.property( 'message' ).and
+							// eslint-disable-next-line max-len
+							.match( /^editor-create-initial-data: The config\.initialData option cannot be used together with initial data passed in Editor\.create\(\)\./ );
+					}
+				)
+				.then( done )
+				.catch( done );
 		} );
 
 		it( 'throws error if it is initialized in textarea', done => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: `DecoupledEditor.create()` will throw an error, when textarea element is used.

---

### Additional information

* PR requires: ckeditor/ckeditor5-core#173