### PR TITLE
Add label for decoupled editor's toolbar

### DIFF
--- a/src/decouplededitorui.js
+++ b/src/decouplededitorui.js
@@ -116,6 +116,8 @@ export default class DecoupledEditorUI extends EditorUI {
 
 		toolbar.fillFromConfig( this._toolbarConfig.items, this.componentFactory );
 
+		toolbar.label = editor.t( this._toolbarConfig.label );
+
 		enableToolbarKeyboardFocus( {
 			origin: editor.editing.view,
 			originFocusTracker: this.focusTracker,

--- a/tests/decouplededitorui.js
+++ b/tests/decouplededitorui.js
@@ -52,6 +52,14 @@ describe( 'DecoupledEditorUI', () => {
 			expect( view.isRendered ).to.be.true;
 		} );
 
+		it( 'renders accessibility label for toolbar', () => {
+			const labelEl = view.toolbar.element.lastChild;
+
+			expect( labelEl.tagName ).to.equal( 'SPAN' );
+			expect( labelEl.classList.contains( 'ck-toolbar__label' ) ).to.be.true;
+			expect( labelEl.innerText ).to.equal( 'Editor\'s toolbar' );
+		} );
+
 		describe( 'editable', () => {
 			it( 'registers view.editable#element in editor focus tracker', () => {
 				ui.focusTracker.isFocused = false;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Add label for decoupled editor's toolbar.

---

### Additional information

* Main PR: ckeditor/ckeditor5-ui#500
