### PR TITLE
t/ckeditor5/1838: Used the new `EditorUI#setEditableElement()` API in the `DecoupledEditorUI` class

### DIFF
--- a/src/decouplededitorui.js
+++ b/src/decouplededitorui.js
@@ -66,7 +66,7 @@ export default class DecoupledEditorUI extends EditorUI {
 
 		// Register the editable UI view in the editor. A single editor instance can aggregate multiple
 		// editable areas (roots) but the decoupled editor has only one.
-		this._editableElements.set( editable.name, editableElement );
+		this.setEditableElement( editable.name, editableElement );
 
 		// Let the global focus tracker know that the editable UI element is focusable and
 		// belongs to the editor. From now on, the focus tracker will sustain the editor focus


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Used the new `EditorUI#setEditableElement()` API in the `DecoupledEditorUI` class (see ckeditor/ckeditor5#1838).

---

A piece of ckeditor/ckeditor5#1840.