### PR TITLE
Fixed a Webpack warning related to nonexisting import

### DIFF
--- a/tests/manual/decouplededitor.js
+++ b/tests/manual/decouplededitor.js
@@ -13,7 +13,7 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Undo from '@ckeditor/ckeditor5-undo/src/undo';
 import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
-import testUtils from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
+import { createObserver } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 
 const editorData = '<h2>Hello world</h2><p>This is the decoupled editor.</p>';
 let editor, editable, observer;
@@ -34,7 +34,7 @@ function initEditor() {
 			window.editor = editor = newEditor;
 			window.editable = editable = editor.editing.view.document.getRoot();
 
-			observer = testUtils.createObserver();
+			observer = createObserver();
 			observer.observe( 'Editable', editable, [ 'isFocused' ] );
 		} )
 		.catch( err => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Fixed a warning about importing non-existing default export, displayed by Webpack.

---

### Additional information

While working on something I started to get errors like that:

![image](https://user-images.githubusercontent.com/5353898/61776218-df391480-adfa-11e9-9bd3-f1b9149ace4f.png)

when recompiling manual tests.

* I have skipped a dedicated issue as it's a micro change.
